### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,20 +14,20 @@ Screenshot
 --------------------
 ![AMDraggableBlurView](https://raw.githubusercontent.com/andreamazz/AMDraggableBlurView/master/screenshot.gif)
 
-Setup with Cocoapods
+Setup with CocoaPods
 --------------------
 * Add ```pod 'AMDraggableBlurView'``` to your Podfile
 * Run ```pod install```
 * Run ```open App.xcworkspace```
 * Add ```AMDraggableBlurView```s to your storyboard or in your code.
 
-Setup without Cocoapods
+Setup without CocoaPods
 --------------------
 * Clone this repo
 * Add the ```AMDraggableBlurView``` folder to your project
 * Import ```AMDraggableBlurView.h``` in your controller's header file
 * Add ```AMDraggableBlurView```s to your storyboard or in your code.
-* Start using Cocoapods ;)
+* Start using CocoaPods ;)
 
 Create a blurred view
 --------------------


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
